### PR TITLE
Refactoring fix test diff count0

### DIFF
--- a/cpp/tests/graph_ops/csr_add_self_loop_utils.cu
+++ b/cpp/tests/graph_ops/csr_add_self_loop_utils.cu
@@ -148,7 +148,7 @@ void host_get_csr_add_self_loop(int* host_csr_row_ptr,
 {
   for (int64_t row_id = 0; row_id < csr_row_ptr_array_desc.size - 1; row_id++) {
     int start                                   = host_csr_row_ptr[row_id];
-    int end                                     = host_csr_col_ptr[row_id + 1];
+    int end                                     = host_csr_row_ptr[row_id + 1];
     host_ref_output_csr_row_ptr[row_id]         = start + row_id;
     host_ref_output_csr_col_ptr[start + row_id] = row_id;
     for (int64_t j = start; j < end; j++) {

--- a/cpp/tests/wholegraph_ops/graph_sampling_test_utils.cu
+++ b/cpp/tests/wholegraph_ops/graph_sampling_test_utils.cu
@@ -652,7 +652,7 @@ void host_weighted_sample_without_replacement(
           }
         }
       };
-#if 1
+
       for (int j = 0; j < block_size; j++) {
         int local_gidx = gidx + j;
         PCGenerator rng(random_seed, (uint64_t)local_gidx, (uint64_t)0);
@@ -672,16 +672,7 @@ void host_weighted_sample_without_replacement(
           }
         }
       }
-#else
 
-      for (int j = 0; j < block_size; j++) {
-        int local_gidx = gidx + j;
-        PCGenerator rng(random_seed, (uint64_t)local_gidx, (uint64_t)0);
-        for (int id = j; id < neighbor_count; id += block_size) {
-          if (id < neighbor_count) { consume_fun(id, rng); }
-        }
-      }
-#endif
 
       for (int sample_id = 0; sample_id < max_sample_count; sample_id++) {
         output_dest_nodes_ptr[output_id + sample_id] = csr_col_ptr[start + small_heap.top().first];

--- a/cpp/tests/wholegraph_ops/wholegraph_csr_weighted_sample_without_replacement_tests.cu
+++ b/cpp/tests/wholegraph_ops/wholegraph_csr_weighted_sample_without_replacement_tests.cu
@@ -369,7 +369,13 @@ TEST_P(WholeGraphCSRWeightedSampleWithoutReplacementParameterTests, WeightedSamp
         random_seed);
 
       EXPECT_EQ(total_sample_count, host_total_sample_count);
-
+      wholegraph_ops::testing::segment_sort_output(
+        host_ref_output_sample_offset,
+        output_sample_offset_desc,
+        host_ref_output_dest_nodes,
+        wholememory_create_array_desc(host_total_sample_count, 0, csr_col_ptr_desc.dtype),
+        host_ref_output_global_edge_id,
+        wholememory_create_array_desc(host_total_sample_count, 0, WHOLEMEMORY_DT_INT64));
       wholegraph_ops::testing::host_check_two_array_same(host_output_sample_offset,
                                                          output_sample_offset_desc,
                                                          host_ref_output_sample_offset,


### PR DESCRIPTION
fix a bug in cpp/tests.

- Initialize diff_count=0
- fix bug in tests/host_csr_add_self_loop
- modify the function `host_weighted_sample_without_replacement` to make the random number generation consistent with the corresponding cuda kernel.